### PR TITLE
Updated \KeyWord with functional (fake) Small Caps

### DIFF
--- a/FieldGuide.sty
+++ b/FieldGuide.sty
@@ -244,7 +244,7 @@
 	\fauxschelphelp#1\relax\relax%
 	\if\relax#2\relax\else\ \fauxschelper#2\relax\fi%
 }
-\def\Hscale{.83}\def\Vscale{.72}\def\Cscale{1.00}
+\def\Hscale{.78}\def\Vscale{.83}\def\Cscale{1.00}
 \def\fauxschelphelp#1#2\relax{%
 	\ifnum`#1=\lccode`#1\relax\scalebox{\Hscale}[\Vscale]{\char\uccode`#1}\else%
 	\scalebox{\Cscale}[1]{#1}\fi%

--- a/FieldGuide.sty
+++ b/FieldGuide.sty
@@ -235,9 +235,24 @@
 \newcommand{\lancercolorbox}[2]{\colorbox{#1}{\begin{minipage}{\linewidth}{\textcolor{white}{#2}}\end{minipage}}}
 \newcommand{\redbox}[1]{\textbf{\lancercolorbox{red}{#1}}}
 
+% Definition of \fauxsc, used in \KeyWord to turn it into Small Caps
+% Original by: Steven B. Segletes @ StackExchange
+% Source: https://tex.stackexchange.com/a/225078
+\makeatother
+\newcommand\fauxsc[1]{\fauxschelper#1 \relax\relax}
+\def\fauxschelper#1 #2\relax{%
+	\fauxschelphelp#1\relax\relax%
+	\if\relax#2\relax\else\ \fauxschelper#2\relax\fi%
+}
+\def\Hscale{.83}\def\Vscale{.72}\def\Cscale{1.00}
+\def\fauxschelphelp#1#2\relax{%
+	\ifnum`#1=\lccode`#1\relax\scalebox{\Hscale}[\Vscale]{\char\uccode`#1}\else%
+	\scalebox{\Cscale}[1]{#1}\fi%
+	\ifx\relax#2\relax\else\fauxschelphelp#2\relax\fi}
+
 % Command for formatting a word as a KeyWord, 
 % in small caps and bold, but smushed together
-\newcommand{\KeyWord}[1]{\so{\textsc{\textbf{#1}}}}
+\newcommand{\KeyWord}[1]{\so{\textbf{\protect\fauxsc{#1}}}}
 
 % Command for Horus text
 \NewDocumentCommand{\HorusText}{m}


### PR DESCRIPTION
The Arimo font lacks Small Caps, so it does not show them on compile:

![image](https://user-images.githubusercontent.com/6154545/196571712-ace3f8ea-631c-4863-a853-f892df31385d.png)

This version makes "fake" small caps using the default font (for this latex template, that's Arimo) using the techniques presented in this StackExchange answer: https://tex.stackexchange.com/a/225078

The result looks like this:

![image](https://user-images.githubusercontent.com/6154545/196572531-e97ca935-5d99-4283-9f5d-79be051e2bb5.png)

While far from a perfect solution (the best would be the font itself providing its own small caps), it does a pretty decent job.